### PR TITLE
Added Application Analytics

### DIFF
--- a/src/applications/applications.controller.ts
+++ b/src/applications/applications.controller.ts
@@ -8,7 +8,10 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Query,
+  Req,
 } from '@nestjs/common';
+import { Request } from 'express';
 
 import { IResponse } from 'types/IResponse';
 import {
@@ -40,10 +43,12 @@ export class ApplicationsController {
   @Get(':aidn')
   @HttpCode(HttpStatus.OK)
   async getApplication(
+    @Req() req: Request,
     @Param('aidn', ParseIntPipe) aidn: number,
+    @Query() query?: { verbose: string },
   ): Promise<IResponse> {
     logger.info(`GET /applications/${aidn} initiated`);
-    return this.applicationsService.getOneApplication(aidn);
+    return this.applicationsService.getOneApplication(req, aidn, query);
   }
 
   @Post(':aidn')

--- a/utils/verifyAppchain.ts
+++ b/utils/verifyAppchain.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../src/prisma/prisma.service';
 import { Application } from '@prisma/client';
 import { handlePrismaErrors } from './handlePrismaErrors';
@@ -14,7 +18,7 @@ export async function verifyAppchain(
 
   if (aidn === undefined || appchain === undefined) {
     throw new BadRequestException('aidn or appchain missing in verifyAppchain');
-  };
+  }
 
   try {
     // gets one application from given aidn

--- a/utils/verifyAppchain.ts
+++ b/utils/verifyAppchain.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../src/prisma/prisma.service';
 import { Application } from '@prisma/client';
 import { handlePrismaErrors } from './handlePrismaErrors';
@@ -12,6 +12,10 @@ export async function verifyAppchain(
 ): Promise<boolean> {
   let application: Application;
 
+  if (aidn === undefined || appchain === undefined) {
+    throw new BadRequestException('aidn or appchain missing in verifyAppchain');
+  };
+
   try {
     // gets one application from given aidn
     logger.info(
@@ -20,7 +24,6 @@ export async function verifyAppchain(
     application = await prisma.application.findUnique({
       where: { aidn },
     });
-
   } catch (error) {
     // handle any prisma errors that come up
     logger.error({


### PR DESCRIPTION
Users can now return the following stats when retrieving data for one Application:
- Total closed keychains associated with the app
- Total open keychains associated with the app
- Total unique users using the app
- Total transactions made with this app